### PR TITLE
Respect `expose` prop in errors

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -66,6 +66,8 @@ Your handler function needs to return a `Response` object, or a `Promise` that r
 
 Like [`paperplane`](https://github.com/articulate/paperplane/blob/v3.1.1/docs/getting-started.md#request-object), this library will support [`boom`](https://www.npmjs.com/package/boom), [`http-errors`](https://www.npmjs.com/package/http-errors), & [`joi`](https://www.npmjs.com/package/joi) errors.
 
+Like [Koa](https://github.com/koajs/koa/blob/master/docs/error-handling.md#default-error-handler), if the status code is a client-error, 400-level error status, the error's message & payload, if applicable, will be used as the response body. The response body will be omitted on server-error, 500-level errors. You can override this behavior by setting the `expose` property to `true` or `false` on the error.
+
 An error will be [`emitted to the koa application`](https://github.com/koajs/koa/wiki/Error-Handling) if one of the following is true:
 * The response's status code is greater than or equal to `500`.
 * The error encountered contains a `cry: true` property.

--- a/index.js
+++ b/index.js
@@ -14,6 +14,7 @@ const {
   compose,
   converge,
   curry,
+  dissoc,
   either,
   merge,
   path,
@@ -61,6 +62,10 @@ const handleError = curry((ctx, err) => {
 
   if (res.statusCode >= 500 || err.cry) {
     ctx.app.emit('error', err, ctx)
+  }
+
+  if (err.expose === false || (err.expose == null && res.statusCode >= 500)) {
+    return dissoc('body', res)
   }
 
   return res


### PR DESCRIPTION
First fragmentation with paperplane. That didn't take long.

This proposal will respect the `expose` property on errors--a pattern used by Koa, express, & [`http-errors`](https://www.npmjs.com/package/http-errors).

* If `expose === true`, the response will include a body
* If `expose === false`, the response will not include a body
* If `expose == null`, then only 400-level errors will include a body

This will prevent internal server errors from leaking system internals to end users.